### PR TITLE
update field name from zeek site

### DIFF
--- a/zeek/files/events/x509.yml
+++ b/zeek/files/events/x509.yml
@@ -19,13 +19,13 @@ event_fields:
   sample_value: '``'
 - standard_name: TBD
   standard_type: TBD
-  name: basic_constraints_ca
+  name: basic_constraints.ca
   type: boolean
   description: CA flag set
   sample_value: 'false'
 - standard_name: TBD
   standard_type: TBD
-  name: basic_constraints_path_len
+  name: basic_constraints.path_len
   type: integer
   description: Maximum path length
   sample_value: '``'
@@ -49,61 +49,61 @@ event_fields:
   sample_value: '``'
 - standard_name: TBD
   standard_type: TBD
-  name: certificate_issuer
+  name: certificate.issuer
   type: string
   description: Issuer
   sample_value: '``'
 - standard_name: TBD
   standard_type: TBD
-  name: certificate_key_alg
+  name: certificate.key_alg
   type: string
   description: Name of the key algorithm
   sample_value: rsaEncryption
 - standard_name: TBD
   standard_type: TBD
-  name: certificate_key_length
+  name: certificate.key_length
   type: integer
   description: Key length in bits
   sample_value: '2084'
 - standard_name: TBD
   standard_type: TBD
-  name: certificate_key_type
+  name: certificate.key_type
   type: string
   description: Key type, if key parsable by openssl (either rsa, dsa or ec)
   sample_value: rsa
 - standard_name: TBD
   standard_type: TBD
-  name: certificate_not_valid_after
+  name: certificate.not_valid_after
   type: date_time
   description: Timestamp after when certificate is not valid
   sample_value: '``'
 - standard_name: TBD
   standard_type: TBD
-  name: certificate_not_valid_before
+  name: certificate.not_valid_before
   type: date_time
   description: Timestamp before when certificate is not valid
   sample_value: '``'
 - standard_name: TBD
   standard_type: TBD
-  name: certificate_serial
+  name: certificate.serial
   type: string
   description: Serial number.
   sample_value: 01F4DB;2F00024CD8CBAD57B4A422DB55000000022CD8
 - standard_name: TBD
   standard_type: TBD
-  name: certificate_sig_alg
+  name: certificate.sig_alg
   type: string
   description: Name of the signature algorithm
   sample_value: dsaWithSHA1
 - standard_name: TBD
   standard_type: TBD
-  name: certificate_subject
+  name: certificate.subject
   type: string
   description: Subject
   sample_value: '``'
 - standard_name: TBD
   standard_type: TBD
-  name: certificate_version
+  name: certificate.version
   type: integer
   description: Version number
   sample_value: '``'
@@ -116,7 +116,7 @@ event_fields:
   sample_value: 'true'
 - standard_name: TBD
   standard_type: TBD
-  name: san_dns
+  name: san.dns
   type: array_string
   description: List of DNS entries in SAN
   sample_value: bobsyauncle.domain.local


### PR DESCRIPTION
When check sigma rule find a diff ("_" rather than ".").
Fix name according to the reference https://docs.zeek.org/en/v4.1.1/logs/x509.html
Some field name are not in the reference.