### PR TITLE
Updated and Added Data Dictionaries

### DIFF
--- a/windows/etw-providers/Microsoft-Windows-Eventlog/events/event-104.yml
+++ b/windows/etw-providers/Microsoft-Windows-Eventlog/events/event-104.yml
@@ -1,28 +1,28 @@
-name: Event 104 - Logclear
-description:
+name: Event 104 - A log file was cleared
+description: This event generates every time a log files is cleared
 platform: windows
 log_source: Microsoft-Windows-Eventlog
 event_id: '104'
 event_version: '0'
 event_fields:
-- standard_name: TBD
+- standard_name: user_name
   standard_type: TBD
   name: SubjectUserName
   type: UnicodeString
-  description:
-  sample_value:
-- standard_name: TBD
+  description: The name of the account that cleared the log file
+  sample_value: pedro
+- standard_name: user_domain
   standard_type: TBD
   name: SubjectDomainName
   type: UnicodeString
-  description:
-  sample_value:
+  description: Subject's domain or computer name
+  sample_value: PEDRO01
 - standard_name: TBD
   standard_type: TBD
   name: Channel
   type: UnicodeString
-  description:
-  sample_value:
+  description: Name of Log file cleared
+  sample_value: Microsoft-Windows-PowerShell/Operational
 - standard_name: TBD
   standard_type: TBD
   name: BackupPath
@@ -33,3 +33,32 @@ references:
 tags:
 - etw_level_Informational
 - etw_task_Logclear
+event_sample:
+- format: xml
+  sample: |-
+    <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
+      <System> 
+        <Provider Name="Microsoft-Windows-Eventlog" Guid="{fc65ddd8-d6ef-4962-83d5-6e5cfe9ce148}" /> 
+        <EventID>104</EventID> 
+        <Version>0</Version> 
+        <Level>4</Level> 
+        <Task>104</Task> 
+        <Opcode>0</Opcode> 
+        <Keywords>0x8000000000000000</Keywords> 
+        <TimeCreated SystemTime="2022-08-09T14:44:05.786938100Z" /> 
+        <EventRecordID>1113</EventRecordID> 
+        <Correlation /> 
+        <Execution ProcessID="1444" ThreadID="2044" /> 
+        <Channel>System</Channel> 
+        <Computer>Pedro01</Computer> 
+        <Security UserID="S-1-5-21-968647429-258479840-2507984072-1001" /> 
+      </System> 
+      <UserData> 
+        <LogFileCleared xmlns="http://manifests.microsoft.com/win/2004/08/windows/eventlog"> 
+          <SubjectUserName>pedro</SubjectUserName> 
+          <SubjectDomainName>PEDRO01</SubjectDomainName> 
+          <Channel>Microsoft-Windows-PowerShell/Operational</Channel> 
+          <BackupPath> </BackupPath> 
+        </LogFileCleared> 
+      </UserData> 
+    </Event> 

--- a/windows/etw-providers/Microsoft-Windows-Eventlog/events/event-1100.yml
+++ b/windows/etw-providers/Microsoft-Windows-Eventlog/events/event-1100.yml
@@ -1,0 +1,36 @@
+name: Event 1100 - Windows Event Log service has shut down
+description: This event generates every time Windows Event Log service has shut down
+platform: windows
+log_source: Microsoft-Windows-Eventlog
+event_id: '1101'
+event_version: '0'
+event_fields: []
+references:
+- https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-1100
+tags:
+- etw_level_Informational
+event_sample:
+- format: xml
+  sample: |-
+    <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
+      <System> 
+        <Provider Name="Microsoft-Windows-Eventlog" Guid="{fc65ddd8-d6ef-4962-83d5-6e5cfe9ce148}" /> 
+        <EventID>1100</EventID> 
+        <Version>0</Version> 
+        <Level>4</Level> 
+        <Task>103</Task> 
+        <Opcode>0</Opcode> 
+        <Keywords>0x4020000000000000</Keywords> 
+        <TimeCreated SystemTime="2022-08-08T19:56:55.801610900Z" /> 
+        <EventRecordID>243916</EventRecordID> 
+        <Correlation /> 
+        <Execution ProcessID="976" ThreadID="6056" /> 
+        <Channel>Security</Channel> 
+        <Computer>Pedro01</Computer> 
+        <Security /> 
+      </System> 
+      <UserData> 
+        <ServiceShutdown xmlns="http://manifests.microsoft.com/win/2004/08/windows/eventlog"> 
+        </ServiceShutdown> 
+      </UserData> 
+    </Event>

--- a/windows/etw-providers/Microsoft-Windows-Eventlog/events/event-1102.yml
+++ b/windows/etw-providers/Microsoft-Windows-Eventlog/events/event-1102.yml
@@ -1,35 +1,65 @@
-name: Event 1102 - Logclear
-description:
+name: Event 1102 - The audit log was cleared
+description: This event generates every time Windows Security audit log files is cleared
 platform: windows
 log_source: Microsoft-Windows-Eventlog
 event_id: '1102'
 event_version: '0'
 event_fields:
-- standard_name: TBD
+- standard_name: user_sid
   standard_type: TBD
   name: SubjectUserSid
   type: SID
-  description:
-  sample_value:
-- standard_name: TBD
+  description: SID of the account that cleared the system security audit log
+  sample_value: S-1-5-21-968647429-258479840-2507984072-1001
+- standard_name: user_name
   standard_type: TBD
   name: SubjectUserName
   type: UnicodeString
-  description:
-  sample_value:
-- standard_name: TBD
+  description: The name of the account that cleared the system security audit log
+  sample_value: pedro
+- standard_name: user_domain
   standard_type: TBD
   name: SubjectDomainName
   type: UnicodeString
-  description:
-  sample_value:
-- standard_name: TBD
+  description: Subject's domain or computer name
+  sample_value: PEDRO01
+- standard_name: user_logon_id
   standard_type: TBD
   name: SubjectLogonId
   type: HexInt64
-  description:
-  sample_value:
+  description: Logon ID of the subject's logon session
+  sample_value: 0x20256d6
 references:
+- https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-1102
 tags:
 - etw_level_Informational
 - etw_task_Logclear
+event_sample:
+- format: xml
+  sample: |-
+    <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
+      <System> 
+        <Provider Name="Microsoft-Windows-Eventlog" Guid="{fc65ddd8-d6ef-4962-83d5-6e5cfe9ce148}" /> 
+        <EventID>1102</EventID> 
+        <Version>0</Version> 
+        <Level>4</Level> 
+        <Task>104</Task> 
+        <Opcode>0</Opcode> 
+        <Keywords>0x4020000000000000</Keywords> 
+        <TimeCreated SystemTime="2022-08-09T14:44:05.629920700Z" /> 
+        <EventRecordID>266417</EventRecordID> 
+        <Correlation /> 
+        <Execution ProcessID="1444" ThreadID="2044" /> 
+        <Channel>Security</Channel> 
+        <Computer>Pedro01</Computer> 
+        <Security /> 
+      </System> 
+      <UserData> 
+        <LogFileCleared xmlns="http://manifests.microsoft.com/win/2004/08/windows/eventlog"> 
+          <SubjectUserSid>S-1-5-21-968647429-258479840-2507984072-1001</SubjectUserSid> 
+          <SubjectUserName>pedro</SubjectUserName> 
+          <SubjectDomainName>PEDRO01</SubjectDomainName> 
+          <SubjectLogonId>0x20256d6</SubjectLogonId> 
+        </LogFileCleared> 
+      </UserData> 
+    </Event> 

--- a/windows/etw-providers/Microsoft-Windows-Eventlog/events/event-6005.yml
+++ b/windows/etw-providers/Microsoft-Windows-Eventlog/events/event-6005.yml
@@ -1,0 +1,37 @@
+name: Event 6005 - The Event Log service was started
+description: The Event Log service was started. Indicates the system startup.
+platform: windows
+log_source: Microsoft-Windows-Eventlog
+event_id: '6005'
+event_version: '0'
+event_fields:
+- standard_name: TBD
+  standard_type: TBD
+  name: Binary
+  type: TBD
+  description: TBD
+  sample_value: E607080002000900100009001B0038000000000000000000
+references:
+- https://www.shellhacks.com/windows-shutdown-reboot-event-ids-get-logs/
+tags:
+- etw_level_Informational
+event_sample:
+- format: xml
+  sample: |-
+    <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
+      <System> 
+        <Provider Name="EventLog" /> 
+        <EventID Qualifiers="32768">6005</EventID> 
+        <Level>4</Level> 
+        <Task>0</Task> 
+        <Keywords>0x80000000000000</Keywords> 
+        <TimeCreated SystemTime="2022-08-09T16:09:27.056581000Z" /> 
+        <EventRecordID>686</EventRecordID> 
+        <Channel>System</Channel> 
+        <Computer>Pedro01</Computer> 
+        <Security /> 
+      </System> 
+      <EventData> 
+        <Binary>E607080002000900100009001B0038000000000000000000</Binary> 
+      </EventData> 
+    </Event> 

--- a/windows/etw-providers/Microsoft-Windows-Eventlog/events/event-6006.yml
+++ b/windows/etw-providers/Microsoft-Windows-Eventlog/events/event-6006.yml
@@ -1,0 +1,37 @@
+name: Event 6006 - The Event Log service was stopped
+description: The Event Log service was stopped. Indicates the proper system shutdown.
+platform: windows
+log_source: Microsoft-Windows-Eventlog
+event_id: '6006'
+event_version: '0'
+event_fields:
+- standard_name: TBD
+  standard_type: TBD
+  name: Binary
+  type: TBD
+  description: TBD
+  sample_value: 0100000031F40800
+references:
+- https://www.shellhacks.com/windows-shutdown-reboot-event-ids-get-logs/
+tags:
+- etw_level_Informational
+event_sample:
+- format: xml
+  sample: |-
+    <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
+      <System> 
+        <Provider Name="EventLog" /> 
+        <EventID Qualifiers="32768">6006</EventID> 
+        <Level>4</Level> 
+        <Task>0</Task> 
+        <Keywords>0x80000000000000</Keywords> 
+        <TimeCreated SystemTime="2022-08-09T16:08:38.915070600Z" /> 
+        <EventRecordID>678</EventRecordID> 
+        <Channel>System</Channel> 
+        <Computer>Pedro01</Computer> 
+        <Security /> 
+      </System> 
+      <EventData> 
+        <Binary>0100000031F40800</Binary> 
+      </EventData> 
+    </Event> 

--- a/windows/etw-providers/Microsoft-Windows-Security-Auditing/events/event-4656_service_v1.yml
+++ b/windows/etw-providers/Microsoft-Windows-Security-Auditing/events/event-4656_service_v1.yml
@@ -1,59 +1,59 @@
-name: 'Event ID 4656: A handle to a registry object was requested'
-description: This event indicates that specific access was requested for a registry object.
+name: 'Event ID 4656: A handle to a service object was requested'
+description: This event indicates that specific access was requested for a service object.
 platform: windows
 log_source: Microsoft-Windows-Security-Auditing
 event_id: '4656'
 event_version: '1'
-event_mask: registry
+event_mask: service
 event_fields:
 - standard_name: user_sid
   standard_type: TBD
   name: SubjectUserSid
   type: SID
-  description: SID of account that requested a handle to a registry object.
-  sample_value: S-1-5-21-3457937927-2839227994-823803824-1104
+  description: SID of account that requested a handle to a service object.
+  sample_value: S-1-5-21-2073674718-3587034731-622476709-1001
 - standard_name: user_name
   standard_type: TBD
   name: SubjectUserName
   type: UnicodeString
-  description: the name of the account that requested a handle to a registry object.
-  sample_value: dadmin
+  description: the name of the account that requested a handle to a service object.
+  sample_value: pedro
 - standard_name: user_domain
   standard_type: TBD
   name: SubjectDomainName
   type: UnicodeString
   description: Subject's domain or computer name.
-  sample_value: CONTOSO
+  sample_value: DESKTOP-CQF82L6
 - standard_name: user_logon_id
   standard_type: TBD
   name: SubjectLogonId
   type: HexInt64
   description: hexadecimal value that can help you correlate this event with recent events that might contain the same Logon ID
-  sample_value: '0x4367b'
+  sample_value: '0x4E20D'
 - standard_name: object_server
   standard_type: TBD
   name: ObjectServer
   type: UnicodeString
-  description: Security
-  sample_value: Security
+  description: SC Manager for service object.
+  sample_value: SC Manager
 - standard_name: object_type
   standard_type: TBD
   name: ObjectType
   type: UnicodeString
   description: The type of an object that was accessed during the operation.
-  sample_value: Key
-- standard_name: registry_key_path
+  sample_value: SERVICE OBJECT
+- standard_name: service_name
   standard_type: TBD
   name: ObjectName
   type: UnicodeString
-  description: name and other identifying information for the object for which access was requested. For example, for a file, the path would be included.
-  sample_value: \REGISTRY\MACHINE\SYSTEM\ControlSet001\Services\EventLog
-- standard_name: registry_key_handle_id
+  description: name and other identifying information for the service object for which access was requested.
+  sample_value: EventLog
+- standard_name: service_handle_id
   standard_type: TBD
   name: HandleId
   type: Pointer
-  description: 'hexadecimal value of a handle to registry key path. This field can help you correlate this event with other events that might contain the same Handle ID, for example, "4663(S): An attempt was made to access an object."'
-  sample_value: '0x0'
+  description: 'hexadecimal value of a handle to service object Name. This field can help you correlate this event with other events that might contain the same Handle ID, for example, "4663(S): An attempt was made to access an object."'
+  sample_value: '0x16fa36af2a0'
 - standard_name: transaction_guid
   standard_type: TBD
   name: TransactionId
@@ -65,19 +65,19 @@ event_fields:
   name: AccessList
   type: UnicodeString
   description: the list of access rights which were requested by Subject\Security ID.
-  sample_value: '%%1538 %%1541 %%4416 %%4417 %%4418 %%4419 %%4420 %%4423 %%4424'
+  sample_value: '%%7189'
 - standard_name: object_access_reason
   standard_type: TBD
   name: AccessReason
   type: UnicodeString
   description: the list of access check results. The format of this varies, depending on the object. For kernel objects, this field does not apply.
-  sample_value: '%%1538: %%1804 %%1541: %%1809 %%4416: %%1809 %%4417: %%1809 %%4418: %%1802 D:(D;;LC;;;S-1-5-21-3457937927-2839227994-823803824-1104) %%4419: %%1809 %%4420: %%1809 %%4423: %%1811 D:(A;OICI;FA;;;S-1-5-21-3457937927-2839227994-823803824-1104) %%4424: %%1809'
+  sample_value: '-'
 - standard_name: object_access_mask
   standard_type: TBD
   name: AccessMask
   type: HexInt32
   description: hexadecimal mask for the requested or performed operation. For more information, see the preceding table.
-  sample_value: '0x12019f'
+  sample_value: '0x20'
 - standard_name: user_privilege_list
   standard_type: TBD
   name: PrivilegeList
@@ -89,25 +89,25 @@ event_fields:
   name: RestrictedSidCount
   type: UInt32
   description: Number of restricted SIDs in the token. Applicable to only specific Object Types.
-  sample_value: '-'
+  sample_value: '0'
 - standard_name: process_id
   standard_type: TBD
   name: ProcessId
   type: Pointer
   description: hexadecimal Process ID of the process through which the access was requested.
-  sample_value: '0x1074'
+  sample_value: '0x270'
 - standard_name: process_file_path
   standard_type: TBD
   name: ProcessName
   type: UnicodeString
   description: full path and the name of the executable for the process.
-  sample_value: C:\Windows\System32\notepad.exe
+  sample_value: C:\Windows\System32\services.exe
 - standard_name: object_resource_attributes
   standard_type: TBD
   name: ResourceAttributes
   type: UnicodeString
   description: attributes associated with the object. For some objects, the field does not apply and "-" is displayed
-  sample_value: S:AI(RA;ID;;;;WD;("Impact_MS",TI,0x10020,3000))
+  sample_value: '-'
 references:
 - text: MS Source
   link: https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/auditing/event-4656.md
@@ -132,22 +132,40 @@ tags:
 event_sample:
 - format: xml
   sample: |-
-    <EventData>
-    <Data Name="SubjectUserSid">S-1-5-18</Data>
-    <Data Name="SubjectUserName">DESKTOP-CQF82L6$</Data>
-    <Data Name="SubjectDomainName">WORKGROUP</Data>
-    <Data Name="SubjectLogonId">0x3e7</Data>
-    <Data Name="ObjectServer">Security</Data>
-    <Data Name="ObjectType">File</Data>
-    <Data Name="ObjectName">C:\Windows\servicing</Data>
-    <Data Name="HandleId">0x554</Data>
-    <Data Name="TransactionId">{00000000-0000-0000-0000-000000000000}</Data>
-    <Data Name="AccessList">%%1541 %%4416</Data>
-    <Data Name="AccessReason">-</Data>
-    <Data Name="AccessMask">0x100001</Data>
-    <Data Name="PrivilegeList">SeBackupPrivilege</Data>
-    <Data Name="RestrictedSidCount">0</Data>
-    <Data Name="ProcessId">0x558</Data>
-    <Data Name="ProcessName">C:\ProgramData\Microsoft\Windows Defender\Platform\4.18.2205.7-0\MsMpEng.exe</Data>
-    <Data Name="ResourceAttributes">-</Data>
-    </EventData>
+    <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
+      <System> 
+        <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-a5ba-3e3b0328c30d}" /> 
+        <EventID>4656</EventID> 
+        <Version>1</Version> 
+        <Level>0</Level> 
+        <Task>12804</Task> 
+        <Opcode>0</Opcode> 
+        <Keywords>0x8020000000000000</Keywords> 
+        <TimeCreated SystemTime="2022-08-08T19:56:55.736170600Z" /> 
+        <EventRecordID>243917</EventRecordID> 
+        <Correlation /> 
+        <Execution ProcessID="4" ThreadID="5768" /> 
+        <Channel>Security</Channel> 
+        <Computer>Pedro01</Computer> 
+        <Security /> 
+      </System> 
+      <EventData> 
+        <Data Name="SubjectUserSid">S-1-5-21-968647429-258479840-2507984072-1001</Data> 
+        <Data Name="SubjectUserName">pedro</Data> 
+        <Data Name="SubjectDomainName">PEDRO01</Data> 
+        <Data Name="SubjectLogonId">0x10bc7c</Data> 
+        <Data Name="ObjectServer">SC Manager</Data> 
+        <Data Name="ObjectType">SERVICE OBJECT</Data> 
+        <Data Name="ObjectName">EventLog</Data>
+        <Data Name="HandleId">0x1a78d22d5a0</Data> 
+        <Data Name="TransactionId">{00000000-0000-0000-0000-000000000000}</Data> 
+        <Data Name="AccessList">%%7189</Data> 
+        <Data Name="AccessReason">-</Data> 
+        <Data Name="AccessMask">0x20</Data> 
+        <Data Name="PrivilegeList">-</Data> 
+        <Data Name="RestrictedSidCount">0</Data> 
+        <Data Name="ProcessId">0x240</Data> 
+        <Data Name="ProcessName">C:\Windows\System32\services.exe</Data> 
+        <Data Name="ResourceAttributes">-</Data> 
+      </EventData> 
+    </Event> 

--- a/windows/etw-providers/Microsoft-Windows-Security-Auditing/events/event-4697.yml
+++ b/windows/etw-providers/Microsoft-Windows-Security-Auditing/events/event-4697.yml
@@ -45,13 +45,13 @@ event_fields:
   standard_type: TBD
   name: ServiceType
   type: HexInt32
-  description: "Indicates the type of service that was registered with the Service Control Manager."
+  description: Indicates the type of service that was registered with the Service Control Manager.
   sample_value: '0x20'
 - standard_name: service_start_type
   standard_type: TBD
   name: ServiceStartType
   type: UInt32
-  description: "The service start type can have one of the following values (see: https://msdn.microsoft.com/library/windows/desktop/ms682450(v=vs.85).aspx)"
+  description: The service start type can have one of the following values (see:https://msdn.microsoft.com/library/windows/desktop/ms682450(v=vs.85).aspx)
   sample_value: '2'
 - standard_name: service_account_name
   standard_type: TBD
@@ -71,3 +71,35 @@ tags:
 - etw_task_task_0
 - System
 - Audit Security System Extension
+event_sample:
+- format: xml
+  sample: |-
+    <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
+      <System> 
+        <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-a5ba-3e3b0328c30d}" /> 
+        <EventID>4697</EventID> 
+        <Version>0</Version> 
+        <Level>0</Level> 
+        <Task>12289</Task> 
+        <Opcode>0</Opcode> 
+        <Keywords>0x8020000000000000</Keywords> 
+        <TimeCreated SystemTime="2022-08-09T02:08:30.109718300Z" /> 
+        <EventRecordID>251716</EventRecordID> 
+        <Correlation ActivityID="{c2f198f9-abad-0000-039a-f1c2adabd801}" /> 
+        <Execution ProcessID="584" ThreadID="640" /> 
+        <Channel>Security</Channel> 
+        <Computer>Pedro01</Computer> 
+        <Security /> 
+      </System> 
+      <EventData> 
+        <Data Name="SubjectUserSid">S-1-5-18</Data> 
+        <Data Name="SubjectUserName">PEDRO01$</Data> 
+        <Data Name="SubjectDomainName">WORKGROUP</Data> 
+        <Data Name="SubjectLogonId">0x3e7</Data> 
+        <Data Name="ServiceName">WpnUserService_abae2</Data> 
+        <Data Name="ServiceFileName">C:\Windows\system32\svchost.exe -k UnistackSvcGroup</Data> 
+        <Data Name="ServiceType">0xe0</Data> 
+        <Data Name="ServiceStartType">2</Data> 
+        <Data Name="ServiceAccount">LocalSystem</Data> 
+      </EventData> 
+    </Event>


### PR DESCRIPTION
- Event 104 - A log file was cleared: Added standard names, descriptions, sample values, and event sample in xml format.
- Event 1100 - Windows Event Log service has shut down: Added dictionary without event fields and added event sample in xml format.
- Event 1102 - The audit log was cleared: standard names, descriptions, sample values, and event sample in xml format.
- Event 6005 - The event log service was started: Added dictionary with event sample in xml format. We still need to review the event fields section of dictionary.
- Event 6006 - The event log service was stopped: Added dictionary with event sample in xml format. We still need to review the event fields section of dictionary.
- Event 4656 - Handle requested to registry object: updated descriptions to make reference to registry objects.
- Event 4656 - handle requested to service object: Added dictionary with event sample in xml format.
- Event 4697 - a service was installed in the system: Removed double quotation marks from descriptions and added event sample in xml format.